### PR TITLE
Add missing exception handlers for ABORTED error responses

### DIFF
--- a/src/main/java/io/atomix/lock/impl/DefaultAsyncAtomicLock.java
+++ b/src/main/java/io/atomix/lock/impl/DefaultAsyncAtomicLock.java
@@ -94,6 +94,13 @@ public class DefaultAsyncAtomicLock
         return retry(LockGrpc.LockStub::unlock, UnlockRequest.newBuilder()
             .setId(id())
             .build())
+            .exceptionally(t -> {
+                if (Status.fromThrowable(t).getCode() == Status.Code.ABORTED) {
+                    return null;
+                } else {
+                    throw (RuntimeException) t;
+                }
+            })
             .thenApply(response -> null);
     }
 


### PR DESCRIPTION
Missing handlers for `ABORTED` errors in `Lock` and `AtomicValue` primitives.