### PR TITLE
Refactor primitive creation

### DIFF
--- a/src/main/java/io/atomix/counter/AtomicCounterBuilder.java
+++ b/src/main/java/io/atomix/counter/AtomicCounterBuilder.java
@@ -7,12 +7,15 @@ package io.atomix.counter;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.counter.v1.CounterGrpc;
 
 /**
  * Builder for AtomicCounter.
  */
-public abstract class AtomicCounterBuilder extends PrimitiveBuilder<AtomicCounterBuilder, AtomicCounter> {
+public abstract class AtomicCounterBuilder
+        extends PrimitiveBuilder<AtomicCounterBuilder, AtomicCounter, CounterGrpc.CounterStub> {
+
     protected AtomicCounterBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, CounterGrpc.newStub(channel), channel.executor());
     }
 }

--- a/src/main/java/io/atomix/counter/impl/DefaultAsyncAtomicCounter.java
+++ b/src/main/java/io/atomix/counter/impl/DefaultAsyncAtomicCounter.java
@@ -7,7 +7,6 @@ package io.atomix.counter.impl;
 
 import io.atomix.api.counter.v1.CloseRequest;
 import io.atomix.api.counter.v1.CounterGrpc;
-import io.atomix.api.counter.v1.CreateRequest;
 import io.atomix.api.counter.v1.DecrementRequest;
 import io.atomix.api.counter.v1.DecrementResponse;
 import io.atomix.api.counter.v1.GetRequest;
@@ -22,7 +21,6 @@ import io.atomix.impl.AbstractAsyncPrimitive;
 import io.grpc.Status;
 
 import java.time.Duration;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -35,15 +33,6 @@ public class DefaultAsyncAtomicCounter
 
     public DefaultAsyncAtomicCounter(String name, CounterGrpc.CounterStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncAtomicCounter> create(Set<String> tags) {
-        return retry(CounterGrpc.CounterStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/countermap/AtomicCounterMapBuilder.java
+++ b/src/main/java/io/atomix/countermap/AtomicCounterMapBuilder.java
@@ -7,6 +7,7 @@ package io.atomix.countermap;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.countermap.v1.CounterMapGrpc;
 
 import java.util.function.Function;
 
@@ -15,12 +16,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder for AtomicCounter.
  */
-public abstract class AtomicCounterMapBuilder<K> extends PrimitiveBuilder<AtomicCounterMapBuilder<K>, AtomicCounterMap<K>> {
+public abstract class AtomicCounterMapBuilder<K>
+        extends PrimitiveBuilder<AtomicCounterMapBuilder<K>, AtomicCounterMap<K>, CounterMapGrpc.CounterMapStub> {
     protected Function<K, String> keyEncoder;
     protected Function<String, K> keyDecoder;
 
     protected AtomicCounterMapBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, CounterMapGrpc.newStub(channel), channel.executor());
     }
 
     /**

--- a/src/main/java/io/atomix/countermap/impl/DefaultAsyncAtomicCounterMap.java
+++ b/src/main/java/io/atomix/countermap/impl/DefaultAsyncAtomicCounterMap.java
@@ -7,7 +7,6 @@ package io.atomix.countermap.impl;
 import io.atomix.api.countermap.v1.CounterMapGrpc;
 import io.atomix.api.countermap.v1.ClearRequest;
 import io.atomix.api.countermap.v1.CloseRequest;
-import io.atomix.api.countermap.v1.CreateRequest;
 import io.atomix.api.countermap.v1.DecrementRequest;
 import io.atomix.api.countermap.v1.DecrementResponse;
 import io.atomix.api.countermap.v1.GetRequest;
@@ -26,7 +25,6 @@ import io.atomix.countermap.AtomicCounterMap;
 import io.atomix.impl.AbstractAsyncPrimitive;
 import io.grpc.Status;
 
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -39,15 +37,6 @@ public class DefaultAsyncAtomicCounterMap
 
     public DefaultAsyncAtomicCounterMap(String name, CounterMapGrpc.CounterMapStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncAtomicCounterMap<String>> create(Set<String> tags) {
-        return retry(CounterMapGrpc.CounterMapStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/election/LeaderElectionBuilder.java
+++ b/src/main/java/io/atomix/election/LeaderElectionBuilder.java
@@ -2,6 +2,7 @@ package io.atomix.election;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.election.v1.LeaderElectionGrpc;
 
 import java.util.function.Function;
 
@@ -10,12 +11,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder for {@link LeaderElection}.
  */
-public abstract class LeaderElectionBuilder<T> extends PrimitiveBuilder<LeaderElectionBuilder<T>, LeaderElection<T>> {
+public abstract class LeaderElectionBuilder<T>
+        extends PrimitiveBuilder<LeaderElectionBuilder<T>, LeaderElection<T>, LeaderElectionGrpc.LeaderElectionStub> {
     protected Function<T, String> encoder;
     protected Function<String, T> decoder;
 
     protected LeaderElectionBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, LeaderElectionGrpc.newStub(channel), channel.executor());
     }
 
     /**

--- a/src/main/java/io/atomix/election/impl/DefaultAsyncLeaderElection.java
+++ b/src/main/java/io/atomix/election/impl/DefaultAsyncLeaderElection.java
@@ -6,7 +6,6 @@ package io.atomix.election.impl;
 
 import io.atomix.api.election.v1.AnointRequest;
 import io.atomix.api.election.v1.CloseRequest;
-import io.atomix.api.election.v1.CreateRequest;
 import io.atomix.api.election.v1.DemoteRequest;
 import io.atomix.api.election.v1.EnterRequest;
 import io.atomix.api.election.v1.EvictRequest;
@@ -25,7 +24,6 @@ import io.atomix.election.LeadershipEventListener;
 import io.atomix.impl.AbstractAsyncPrimitive;
 
 import java.time.Duration;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -40,15 +38,6 @@ public class DefaultAsyncLeaderElection
 
     public DefaultAsyncLeaderElection(String name, LeaderElectionGrpc.LeaderElectionStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncLeaderElection<String>> create(Set<String> tags) {
-        return retry(LeaderElectionGrpc.LeaderElectionStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/impl/AbstractAsyncPrimitive.java
+++ b/src/main/java/io/atomix/impl/AbstractAsyncPrimitive.java
@@ -56,13 +56,6 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive<A, S>, S e
             .build();
     }
 
-    /**
-     * Creates the primitive and connect.Ø
-     *
-     * @return a future to be completed once the primitive is created and connected
-     */
-    protected abstract CompletableFuture<A> create(Set<String> tags);
-
     protected <U, V> CompletableFuture<V> retry(StubMethodCall<T, U, V> callback, U request) {
         return Retries.retryAsync(
             () -> execute(callback, request),

--- a/src/main/java/io/atomix/impl/AbstractAsyncPrimitive.java
+++ b/src/main/java/io/atomix/impl/AbstractAsyncPrimitive.java
@@ -19,7 +19,6 @@ import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/src/main/java/io/atomix/lock/AtomicLockBuilder.java
+++ b/src/main/java/io/atomix/lock/AtomicLockBuilder.java
@@ -2,12 +2,14 @@ package io.atomix.lock;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.lock.v1.LockGrpc;
 
 /**
  * Builder for AtomicLock.
  */
-public abstract class AtomicLockBuilder extends PrimitiveBuilder<AtomicLockBuilder, AtomicLock> {
+public abstract class AtomicLockBuilder extends PrimitiveBuilder<AtomicLockBuilder, AtomicLock, LockGrpc.LockStub> {
+
     protected AtomicLockBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, LockGrpc.newStub(channel), channel.executor());
     }
 }

--- a/src/main/java/io/atomix/lock/DistributedLockBuilder.java
+++ b/src/main/java/io/atomix/lock/DistributedLockBuilder.java
@@ -2,12 +2,14 @@ package io.atomix.lock;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.lock.v1.LockGrpc;
 
 /**
  * Builder for DistributedLock.
  */
-public abstract class DistributedLockBuilder extends PrimitiveBuilder<DistributedLockBuilder, DistributedLock> {
+public abstract class DistributedLockBuilder extends PrimitiveBuilder<DistributedLockBuilder, DistributedLock, LockGrpc.LockStub> {
+
     protected DistributedLockBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, LockGrpc.newStub(channel), channel.executor());
     }
 }

--- a/src/main/java/io/atomix/lock/impl/DefaultAsyncAtomicLock.java
+++ b/src/main/java/io/atomix/lock/impl/DefaultAsyncAtomicLock.java
@@ -1,7 +1,6 @@
 package io.atomix.lock.impl;
 
 import io.atomix.api.lock.v1.CloseRequest;
-import io.atomix.api.lock.v1.CreateRequest;
 import io.atomix.api.lock.v1.GetLockRequest;
 import io.atomix.api.lock.v1.LockGrpc;
 import io.atomix.api.lock.v1.LockRequest;
@@ -14,7 +13,6 @@ import io.grpc.Status;
 
 import java.time.Duration;
 import java.util.OptionalLong;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -24,15 +22,6 @@ public class DefaultAsyncAtomicLock
 
     public DefaultAsyncAtomicLock(String name, LockGrpc.LockStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncAtomicLock> create(Set<String> tags) {
-        return retry(LockGrpc.LockStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/map/AtomicMapBuilder.java
+++ b/src/main/java/io/atomix/map/AtomicMapBuilder.java
@@ -7,6 +7,7 @@ package io.atomix.map;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.map.v1.MapGrpc;
 
 import java.util.function.Function;
 
@@ -15,14 +16,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder for AtomicCounter.
  */
-public abstract class AtomicMapBuilder<K, V> extends PrimitiveBuilder<AtomicMapBuilder<K, V>, AtomicMap<K, V>> {
+public abstract class AtomicMapBuilder<K, V>
+        extends PrimitiveBuilder<AtomicMapBuilder<K, V>, AtomicMap<K, V>, MapGrpc.MapStub> {
     protected Function<K, String> keyEncoder;
     protected Function<String, K> keyDecoder;
     protected Function<V, byte[]> valueEncoder;
     protected Function<byte[], V> valueDecoder;
 
     protected AtomicMapBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, MapGrpc.newStub(channel), channel.executor());
     }
 
     /**

--- a/src/main/java/io/atomix/map/impl/DefaultAsyncAtomicMap.java
+++ b/src/main/java/io/atomix/map/impl/DefaultAsyncAtomicMap.java
@@ -9,7 +9,6 @@ import com.google.protobuf.ByteString;
 import io.atomix.Cancellable;
 import io.atomix.api.map.v1.ClearRequest;
 import io.atomix.api.map.v1.CloseRequest;
-import io.atomix.api.map.v1.CreateRequest;
 import io.atomix.api.map.v1.EntriesRequest;
 import io.atomix.api.map.v1.EventsRequest;
 import io.atomix.api.map.v1.GetRequest;
@@ -42,7 +41,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -58,15 +56,6 @@ public class DefaultAsyncAtomicMap
 
     public DefaultAsyncAtomicMap(String name, MapGrpc.MapStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncAtomicMap<String, byte[]>> create(Set<String> tags) {
-        return retry(MapGrpc.MapStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/multimap/DistributedMultimapBuilder.java
+++ b/src/main/java/io/atomix/multimap/DistributedMultimapBuilder.java
@@ -7,6 +7,7 @@ package io.atomix.multimap;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.multimap.v1.MultiMapGrpc;
 
 import java.util.function.Function;
 
@@ -15,14 +16,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder for AtomicCounter.
  */
-public abstract class DistributedMultimapBuilder<K, V> extends PrimitiveBuilder<DistributedMultimapBuilder<K, V>, DistributedMultimap<K, V>> {
+public abstract class DistributedMultimapBuilder<K, V>
+        extends PrimitiveBuilder<DistributedMultimapBuilder<K, V>, DistributedMultimap<K, V>, MultiMapGrpc.MultiMapStub> {
     protected Function<K, String> keyEncoder;
     protected Function<String, K> keyDecoder;
     protected Function<V, String> valueEncoder;
     protected Function<String, V> valueDecoder;
 
     protected DistributedMultimapBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, MultiMapGrpc.newStub(channel), channel.executor());
     }
 
     /**

--- a/src/main/java/io/atomix/multimap/impl/DefaultAsyncDistributedMultimap.java
+++ b/src/main/java/io/atomix/multimap/impl/DefaultAsyncDistributedMultimap.java
@@ -11,7 +11,6 @@ import io.atomix.api.multimap.v1.ClearRequest;
 import io.atomix.api.multimap.v1.CloseRequest;
 import io.atomix.api.multimap.v1.ContainsRequest;
 import io.atomix.api.multimap.v1.ContainsResponse;
-import io.atomix.api.multimap.v1.CreateRequest;
 import io.atomix.api.multimap.v1.EntriesRequest;
 import io.atomix.api.multimap.v1.Entry;
 import io.atomix.api.multimap.v1.EventsRequest;
@@ -54,7 +53,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -71,15 +69,6 @@ public class DefaultAsyncDistributedMultimap
 
     public DefaultAsyncDistributedMultimap(String name, MultiMapGrpc.MultiMapStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncDistributedMultimap<String, String>> create(Set<String> tags) {
-        return retry(MultiMapGrpc.MultiMapStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/set/DistributedSetBuilder.java
+++ b/src/main/java/io/atomix/set/DistributedSetBuilder.java
@@ -7,6 +7,7 @@ package io.atomix.set;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.set.v1.SetGrpc;
 
 import java.util.function.Function;
 
@@ -15,12 +16,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder for DistributedSet.
  */
-public abstract class DistributedSetBuilder<E> extends PrimitiveBuilder<DistributedSetBuilder<E>, DistributedSet<E>> {
+public abstract class DistributedSetBuilder<E>
+        extends PrimitiveBuilder<DistributedSetBuilder<E>, DistributedSet<E>, SetGrpc.SetStub> {
     protected Function<E, String> elementEncoder;
     protected Function<String, E> elementDecoder;
 
     protected DistributedSetBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, SetGrpc.newStub(channel), channel.executor());
     }
 
     /**

--- a/src/main/java/io/atomix/set/impl/DefaultAsyncDistributedSet.java
+++ b/src/main/java/io/atomix/set/impl/DefaultAsyncDistributedSet.java
@@ -10,7 +10,6 @@ import io.atomix.api.set.v1.ClearRequest;
 import io.atomix.api.set.v1.CloseRequest;
 import io.atomix.api.set.v1.ContainsRequest;
 import io.atomix.api.set.v1.ContainsResponse;
-import io.atomix.api.set.v1.CreateRequest;
 import io.atomix.api.set.v1.Element;
 import io.atomix.api.set.v1.ElementsRequest;
 import io.atomix.api.set.v1.EventsRequest;
@@ -33,7 +32,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -47,15 +45,6 @@ public class DefaultAsyncDistributedSet
 
     public DefaultAsyncDistributedSet(String name, SetGrpc.SetStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncDistributedCollection<String>> create(Set<String> tags) {
-        return retry(SetGrpc.SetStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(response -> this);
     }
 
     @Override

--- a/src/main/java/io/atomix/value/AtomicValueBuilder.java
+++ b/src/main/java/io/atomix/value/AtomicValueBuilder.java
@@ -7,6 +7,7 @@ package io.atomix.value;
 
 import io.atomix.AtomixChannel;
 import io.atomix.PrimitiveBuilder;
+import io.atomix.api.value.v1.ValueGrpc;
 
 import java.util.function.Function;
 
@@ -15,12 +16,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Builder for AtomicValue.
  */
-public abstract class AtomicValueBuilder<V> extends PrimitiveBuilder<AtomicValueBuilder<V>, AtomicValue<V>> {
+public abstract class AtomicValueBuilder<V>
+        extends PrimitiveBuilder<AtomicValueBuilder<V>, AtomicValue<V>, ValueGrpc.ValueStub> {
     protected Function<V, String> encoder;
     protected Function<String, V> decoder;
 
     protected AtomicValueBuilder(AtomixChannel channel) {
-        super(channel);
+        super(channel, ValueGrpc.newStub(channel), channel.executor());
     }
 
     /**

--- a/src/main/java/io/atomix/value/impl/DefaultAsyncAtomicValue.java
+++ b/src/main/java/io/atomix/value/impl/DefaultAsyncAtomicValue.java
@@ -7,7 +7,6 @@ package io.atomix.value.impl;
 import com.google.protobuf.ByteString;
 import io.atomix.Cancellable;
 import io.atomix.api.value.v1.CloseRequest;
-import io.atomix.api.value.v1.CreateRequest;
 import io.atomix.api.value.v1.EventsRequest;
 import io.atomix.api.value.v1.GetRequest;
 import io.atomix.api.value.v1.SetRequest;
@@ -21,7 +20,6 @@ import io.atomix.value.AtomicValueEvent;
 import io.atomix.value.AtomicValueEventListener;
 import io.grpc.Status;
 
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -35,15 +33,6 @@ public class DefaultAsyncAtomicValue
 
     public DefaultAsyncAtomicValue(String name, ValueGrpc.ValueStub stub, ScheduledExecutorService executorService) {
         super(name, stub, executorService);
-    }
-
-    @Override
-    protected CompletableFuture<AsyncAtomicValue<String>> create(Set<String> tags) {
-        return retry(ValueGrpc.ValueStub::create, CreateRequest.newBuilder()
-            .setId(id())
-            .addAllTags(tags)
-            .build())
-            .thenApply(v -> this);
     }
 
     @Override


### PR DESCRIPTION
Merge the create method with buildAsync and move around some utilities function used by create gRPC call.

This is necessary to expose at the builder level the primitive config coming out from the CreateResponse. The config has been recently added to the primitives and this why the submodule has been updated as well.